### PR TITLE
chore: rename issue templates to match commit types

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,7 +1,7 @@
-name: Documentation
+name: Docs
 description: Suggest documentation improvements or additions
 title: "[DOCS] "
-labels: ["documentation"]
+labels: ["docs"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -1,7 +1,7 @@
-name: Feature Request
+name: Feat
 description: Suggest a new feature or improvement
 title: "[FEAT] "
-labels: ["enhancement"]
+labels: ["feat"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -1,7 +1,7 @@
-name: Performance
-description: Report a performance issue or suggest an optimization
-title: "[PERF] "
-labels: ["performance"]
+name: Fix
+description: Report a bug or unexpected behavior
+title: "[FIX] "
+labels: ["fix"]
 body:
   - type: markdown
     attributes:
@@ -13,31 +13,35 @@ body:
     id: description
     attributes:
       label: Description
-      description: Describe the performance issue with observable symptoms.
+      description: A clear description of the bug.
     validations:
       required: true
 
   - type: textarea
-    id: scenario
+    id: steps
     attributes:
-      label: Scenario
-      description: What triggers it? (e.g., large files, many headings, complex markdown)
+      label: Steps to Reproduce
+      description: Minimal steps to trigger the bug.
+      value: |
+        1.
+        2.
+        3.
     validations:
       required: true
 
   - type: textarea
-    id: current-behavior
-    attributes:
-      label: Current Behavior
-      description: What happens now, with metrics if available (e.g., timing, memory usage).
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected-behavior
+    id: expected
     attributes:
       label: Expected Behavior
-      description: What performance you'd expect.
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
     validations:
       required: true
 
@@ -58,9 +62,9 @@ body:
       required: true
 
   - type: textarea
-    id: profiling
+    id: screenshots
     attributes:
-      label: Profiling Data
-      description: Attach profiling output, screenshots, or benchmark results if available.
+      label: Screenshots / Logs
+      description: Paste screenshots or log snippets that help illustrate the issue.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/perf.yml
+++ b/.github/ISSUE_TEMPLATE/perf.yml
@@ -1,7 +1,7 @@
-name: Bug Report
-description: Report a bug or unexpected behavior
-title: "[BUG] "
-labels: ["bug"]
+name: Perf
+description: Report a performance issue or suggest an optimization
+title: "[PERF] "
+labels: ["perf"]
 body:
   - type: markdown
     attributes:
@@ -13,35 +13,31 @@ body:
     id: description
     attributes:
       label: Description
-      description: A clear description of the bug.
+      description: Describe the performance issue with observable symptoms.
     validations:
       required: true
 
   - type: textarea
-    id: steps
+    id: scenario
     attributes:
-      label: Steps to Reproduce
-      description: Minimal steps to trigger the bug.
-      value: |
-        1.
-        2.
-        3.
+      label: Scenario
+      description: What triggers it? (e.g., large files, many headings, complex markdown)
     validations:
       required: true
 
   - type: textarea
-    id: expected
+    id: current-behavior
+    attributes:
+      label: Current Behavior
+      description: What happens now, with metrics if available (e.g., timing, memory usage).
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
     attributes:
       label: Expected Behavior
-      description: What you expected to happen.
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual Behavior
-      description: What actually happened.
+      description: What performance you'd expect.
     validations:
       required: true
 
@@ -62,9 +58,9 @@ body:
       required: true
 
   - type: textarea
-    id: screenshots
+    id: profiling
     attributes:
-      label: Screenshots / Logs
-      description: Paste screenshots or log snippets that help illustrate the issue.
+      label: Profiling Data
+      description: Attach profiling output, screenshots, or benchmark results if available.
     validations:
       required: false


### PR DESCRIPTION
## Summary
- Rename issue templates to match conventional commit types exactly
- `feature_request.yml` → `feat.yml`, `bug_report.yml` → `fix.yml`, `documentation.yml` → `docs.yml`, `performance.yml` → `perf.yml`
- Update internal name, title prefix, and label references
- New labels created: `feat`, `fix`, `docs`, `perf`

## Test plan
- [ ] Verify all 8 templates appear in issue picker with correct names
- [ ] Verify new labels auto-apply when creating issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)